### PR TITLE
Potential fix for code scanning alert no. 4: Binding a socket to all network interfaces

### DIFF
--- a/V6.0.0/Resources/networking.py
+++ b/V6.0.0/Resources/networking.py
@@ -172,12 +172,12 @@ class DLDSPTLocalPeer:
                 break
             peer.send(msg)
     """
-    def __init__(self, port=50505, password="changeme"):
+    def __init__(self, port=50505, password="changeme", bind_addr="127.0.0.1"):
         self.port = port
         self.password = password.encode("utf-8")
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        self.sock.bind(("", port))
+        self.sock.bind((bind_addr, port))
 
     def sign(self, msg):
         return hmac.new(self.password, msg.encode("utf-8"), hashlib.sha256).hexdigest()


### PR DESCRIPTION
Potential fix for [https://github.com/DatLittladucky/DLDSPT/security/code-scanning/4](https://github.com/DatLittladucky/DLDSPT/security/code-scanning/4)

To fix this problem, we should avoid binding the UDP socket to all available interfaces by replacing `self.sock.bind(("", port))` with a bind to a specific, dedicated interface. The best option for typical secure local communication is to use `"127.0.0.1"` for localhost, or to substitute the interface's specific LAN IP (such as `"192.168.x.y"`), depending on the application's use case. If LAN broadcast is actually required, and you want to remain as secure as possible, you should enumerate available local interfaces and only bind to those that are truly necessary (excluding public-facing/redundant interfaces). However, for simplicity and enhanced security, bind to `"127.0.0.1"` if you only want communication through the loopback interface.

To implement, change line 180 from `self.sock.bind(("", port))` to `self.sock.bind(("127.0.0.1", port))`. Optionally make the bind address configurable via an argument (defaulting to `127.0.0.1`).

No new methods or imports are needed; only a change within the shown block for instantiation (the `__init__` method).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
